### PR TITLE
Fixes for the previously merged `TryFrom`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -63,6 +63,14 @@ impl Primitive {
             _ => false,
         }
     }
+
+    fn is_pointer_sized(&self) -> bool {
+        match *self {
+            Primitive::Usize => true,
+            Primitive::Isize => true,
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for Primitive {
@@ -115,22 +123,52 @@ fn main() {
     let cross_tests: Vec<_> = qs.iter().flat_map(|qx| {
         let test_name = syn::Ident::from(format!("i{}f{}", qx.ibits(), qx.fbits));
         let qx_name = syn::Ident::from(format!("{}", qx));
-        let asserts: Vec<_> = qs.iter().map(move |qy| {
+
+        let mut cast_asserts = vec![];
+        let mut from_asserts = vec![];
+        let mut try_from_asserts = vec![];
+
+        for qy in qs.iter() {
             let qy_name = syn::Ident::from(format!("{}", qy));
             if qx.ibits() < qy.ibits() {
-                quote! {
+                cast_asserts.push(quote! {
                     assert_eq!(f64(#qx_name(#qy_name(0.5_f64).unwrap()).unwrap()), 0.5);
+                });
+                if cfg!(feature = "try-from") {
+                    try_from_asserts.push(quote! {
+                        assert_eq!(f64::from(#qx_name::try_from(#qy_name::try_from(0.5_f64).unwrap()).unwrap()), 0.5);
+                    });
                 }
             } else {
-                quote! {
+                cast_asserts.push(quote! {
                     assert_eq!(f64(#qx_name(#qy_name(0.5_f64).unwrap())), 0.5);
+                });
+                if cfg!(feature = "try-from") {
+                    from_asserts.push(quote! {
+                        assert_eq!(f64::from(#qx_name::from(#qy_name::try_from(0.5_f64).unwrap())), 0.5);
+                    });
                 }
             }
-        }).collect();
+        }
         quote! {
-            #[test]
-            fn #test_name() {
-                #(#asserts)*
+            mod #test_name {
+                use super::*;
+
+                #[test]
+                fn cast() {
+                    #(#cast_asserts)*
+                }
+
+                #[test]
+                fn from() {
+                    #(#from_asserts)*
+                }
+
+                #[test]
+                #[cfg(feature = "try-from")]
+                fn try_from() {
+                    #(#try_from_asserts)*
+                }
             }
         }
     }).collect();
@@ -140,10 +178,21 @@ fn main() {
     let mut f = File::create(&file_path).unwrap();
     f.write_all(cross_tokens.to_string().as_bytes()).unwrap();
 
+    let _ = ::std::process::Command::new("rustfmt")
+        .arg("--write-mode")
+        .arg("overwrite")
+        .arg(file_path.to_str().unwrap())
+        .output();
+
     let to_ixx_tests: Vec<_> = qs.iter().flat_map(|q| {
         let test_name = syn::Ident::from(format!("i{}f{}", q.ibits(), q.fbits));
         let q_name = syn::Ident::from(format!("{}", q));
-        let asserts: Vec<_> = PRIMITIVES.iter().map(move |p| {
+
+        let mut cast_asserts = vec![];
+        let mut from_asserts = vec![];
+        let mut try_from_asserts = vec![];
+
+        for p in PRIMITIVES.iter() {
             let p_name = syn::Ident::from(format!("{}", p));
             let (f, i): (f64, u8) = if q.ibits() == 1 {
                 (0.4, 0)
@@ -151,19 +200,44 @@ fn main() {
                 (1.1, 1)
             };
             if p.ibits() < q.ibits() || !p.is_ixx() {
-                quote! {
+                cast_asserts.push(quote! {
                     assert_eq!(#p_name(#q_name(#f).unwrap()).unwrap(), #i as #p_name);
+                });
+                if cfg!(feature = "try-from") && !p.is_pointer_sized() {
+                    try_from_asserts.push(quote! {
+                        assert_eq!(#p_name::try_from(#q_name::try_from(#f).unwrap()).unwrap(), #i as #p_name);
+                    });
                 }
             } else {
-                quote! {
+                cast_asserts.push(quote! {
                     assert_eq!(#p_name(#q_name(#f).unwrap()), #i as #p_name);
+                });
+                if cfg!(feature = "try-from") && !p.is_pointer_sized() {
+                    from_asserts.push(quote! {
+                        assert_eq!(#p_name::from(#q_name::try_from(#f).unwrap()), #i as #p_name);
+                    });
                 }
             }
-        }).collect();
+        }
         quote! {
-            #[test]
-            fn #test_name() {
-                #(#asserts)*
+            mod #test_name {
+                use super::*;
+
+                #[test]
+                fn cast() {
+                    #(#cast_asserts)*
+                }
+
+                #[test]
+                fn from() {
+                    #(#from_asserts)*
+                }
+
+                #[test]
+                #[cfg(feature = "try-from")]
+                fn try_from() {
+                    #(#try_from_asserts)*
+                }
             }
         }
     }).collect();
@@ -173,30 +247,62 @@ fn main() {
     let mut f = File::create(&file_path).unwrap();
     f.write_all(to_ixx_tokens.to_string().as_bytes()).unwrap();
 
+    let _ = ::std::process::Command::new("rustfmt")
+        .arg("--write-mode")
+        .arg("overwrite")
+        .arg(file_path.to_str().unwrap())
+        .output();
+
     let from_ixx_tests: Vec<_> = qs.iter().flat_map(|q| {
         let test_name = syn::Ident::from(format!("i{}f{}", q.ibits(), q.fbits));
         let q_name = syn::Ident::from(format!("{}", q));
-        let asserts: Vec<_> = PRIMITIVES.iter().map(move |p| {
+
+        let mut cast_asserts = vec![];
+        let mut from_asserts = vec![];
+        let mut try_from_asserts = vec![];
+
+        for p in PRIMITIVES.iter() {
             let p_name = syn::Ident::from(format!("{}", p));
-            let i = if q.ibits() == 1 {
-                0
-            } else {
-                1
-            };
+            let i = if q.ibits() == 1 { 0 } else { 1 };
             if p.ibits() <= q.ibits() {
-                quote! {
+                cast_asserts.push(quote! {
                     assert_eq!(f64(#q_name(#i as #p_name)), #i as f64);
+                });
+                if !p.is_pointer_sized() {
+                    from_asserts.push(quote! {
+                        assert_eq!(f64::from(#q_name::from(#i as #p_name)), #i as f64);
+                    });
                 }
             } else {
-                quote! {
+                cast_asserts.push(quote! {
                     assert_eq!(f64(#q_name(#i as #p_name).unwrap()), #i as f64);
+                });
+                if cfg!(feature = "try-from") && !p.is_pointer_sized() {
+                    try_from_asserts.push(quote! {
+                        assert_eq!(f64::from(#q_name::try_from(#i as #p_name).unwrap()), #i as f64);
+                    });
                 }
             }
-        }).collect();
+        }
         quote! {
-            #[test]
-            fn #test_name() {
-                #(#asserts)*
+            mod #test_name {
+                use super::*;
+
+                #[test]
+                fn cast() {
+                    #(#cast_asserts)*
+                }
+
+                #[test]
+                fn from() {
+                    #(#from_asserts)*
+                }
+
+                #[test]
+                #[cfg(feature = "try-from")]
+                fn try_from() {
+                    #(#try_from_asserts)*
+                }
             }
         }
     }).collect();
@@ -205,6 +311,12 @@ fn main() {
     let file_path = Path::new(&out_dir).join("from-ixx.rs");
     let mut f = File::create(&file_path).unwrap();
     f.write_all(from_ixx_tokens.to_string().as_bytes()).unwrap();
+
+    let _ = ::std::process::Command::new("rustfmt")
+        .arg("--write-mode")
+        .arg("overwrite")
+        .arg(file_path.to_str().unwrap())
+        .output();
 
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,10 +91,9 @@ extern crate num_traits;
 use core::cmp::Ordering;
 use core::marker::PhantomData;
 use core::{fmt, ops};
-use core::num::TryFromIntError;
 
 #[cfg(feature = "try-from")]
-use core::convert::{TryFrom, Infallible};
+use core::convert::TryFrom;
 
 use cast::{From as CastFrom, Error, f32, f64, i16, i32, i64, i8, isize, u16, u32, u64, u8, usize};
 use typenum::{Cmp, Greater, Less, U0, U1, U2, U3, U4, U5, U6, U7, U8, U9, U10,
@@ -911,7 +910,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $largest32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -942,7 +941,7 @@ macro_rules! cast {
             }
         #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $largest32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -976,7 +975,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$largest32> for i8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $largest32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1023,7 +1022,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$largest32> for u64 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $largest32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1040,7 +1039,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $largest32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1057,7 +1056,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$largest32> for u32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $largest32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1074,7 +1073,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $largest32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1091,7 +1090,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$largest32> for u16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $largest32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1111,7 +1110,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$largest32> for u8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $largest32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1160,7 +1159,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $large32 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $largest32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -1198,7 +1197,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $medium32 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $largest32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -1232,7 +1231,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $medium16 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $largest32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -1267,7 +1266,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $small32 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $largest32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -1301,7 +1300,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $small16 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $largest32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -1332,7 +1331,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $small8 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $largest32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -1390,7 +1389,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $large32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1421,7 +1420,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $large32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1452,7 +1451,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i16> for $large32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1502,7 +1501,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$large32> for u64 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $large32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1519,7 +1518,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $large32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1536,7 +1535,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$large32> for u32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $large32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1553,7 +1552,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $large32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1570,7 +1569,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$large32> for u16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $large32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1587,7 +1586,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u16> for $large32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1604,7 +1603,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$large32> for u8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $large32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1654,7 +1653,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $large16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1685,7 +1684,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $large16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1716,7 +1715,7 @@ macro_rules! cast {
         }
         #[cfg(feature = "try-from")]
         impl TryFrom<i16> for $large16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1766,7 +1765,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$large16> for u64 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $large16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1783,7 +1782,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $large16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1800,7 +1799,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$large16> for u32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $large16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1817,7 +1816,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $large16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1834,7 +1833,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$large16> for u16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $large16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1851,7 +1850,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u16> for $large16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1868,7 +1867,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$large16> for u8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $large16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -1939,7 +1938,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$large32> for $medium32 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $large32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -1973,7 +1972,7 @@ macro_rules! cast {
                 }
             #[cfg(feature = "try-from")]
             impl TryFrom<$large32> for $medium16 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $large32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -2004,7 +2003,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$large16> for $medium32 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $large16) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -2037,7 +2036,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$large16> for $medium16 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $large16) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -2074,7 +2073,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$large32> for $small32 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $large32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -2108,7 +2107,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$large32> for $small16 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $large32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -2139,7 +2138,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$large32> for $small8 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $large32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -2170,7 +2169,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$large16> for $small32 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $large16) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -2203,7 +2202,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$large16> for $small16 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $large16) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -2236,7 +2235,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$large16> for $small8 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $large16) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -2294,7 +2293,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $medium32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2325,7 +2324,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $medium32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2356,7 +2355,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i16> for $medium32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2387,7 +2386,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i8> for $medium32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i8) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2421,7 +2420,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium32> for u64 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2438,7 +2437,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $medium32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2455,7 +2454,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium32> for u32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2472,7 +2471,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $medium32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2489,7 +2488,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium32> for u16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2506,7 +2505,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u16> for $medium32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2523,7 +2522,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium32> for u8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2540,7 +2539,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u8> for $medium32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u8) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2593,7 +2592,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $medium16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2624,7 +2623,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $medium16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2655,7 +2654,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i16> for $medium16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2686,7 +2685,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i8> for $medium16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i8) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2720,7 +2719,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium16> for u64 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2737,7 +2736,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $medium16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2754,7 +2753,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium16> for u32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2771,7 +2770,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $medium16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2788,7 +2787,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium16> for u16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2805,7 +2804,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u16> for $medium16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2822,7 +2821,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium16> for u8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2839,7 +2838,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u8> for $medium16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u8) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2886,7 +2885,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $medium8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2917,7 +2916,7 @@ macro_rules! cast {
             }
         #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $medium8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2948,7 +2947,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i16> for $medium8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -2979,7 +2978,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i8> for $medium8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: i8) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -3013,7 +3012,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium8> for u64 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium8) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -3030,7 +3029,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $medium8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u64) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -3047,7 +3046,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium8> for u32 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium8) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -3064,7 +3063,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $medium8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u32) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -3081,7 +3080,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium8> for u16 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium8) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -3098,7 +3097,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u16> for $medium8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u16) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -3115,7 +3114,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<$medium8> for u8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: $medium8) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -3132,7 +3131,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<u8> for $medium8 {
-            type Error = TryFromIntError;
+            type Error = Error;
 
             fn try_from(x: u8) -> Result<Self, Self::Error> {
                 Self::cast(x)
@@ -3252,7 +3251,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$medium32> for $small32 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $medium32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -3285,7 +3284,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$medium32> for $small16 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $medium32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -3316,7 +3315,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$medium32> for $small8 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $medium32) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -3347,7 +3346,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$medium16> for $small32 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $medium16) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -3379,7 +3378,7 @@ macro_rules! cast {
             }
             #[cfg(feature = "try-from")]
             impl TryFrom<$medium16> for $small16 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $medium16) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -3412,7 +3411,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$medium16> for $small8 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $medium16) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -3443,7 +3442,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$medium8> for $small32 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $medium8) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -3474,7 +3473,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$medium8> for $small16 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $medium8) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -3507,7 +3506,7 @@ macro_rules! cast {
 
             #[cfg(feature = "try-from")]
             impl TryFrom<$medium8> for $small8 {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $medium8) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -3574,7 +3573,7 @@ macro_rules! to_ixx {
         $(
             #[cfg(feature = "try-from")]
             impl TryFrom<$q> for $ixx {
-                type Error = TryFromIntError;
+                type Error = Error;
 
                 fn try_from(x: $q) -> Result<Self, Self::Error> {
                     Self::cast(x)
@@ -3645,7 +3644,7 @@ to_ixx!(i16;
 
 #[cfg(feature = "try-from")]
 impl TryFrom<u16> for I16F16 {
-    type Error = TryFromIntError;
+    type Error = Error;
 
     fn try_from(x: u16) -> Result<Self, Self::Error> {
         Self::cast(x)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2655,7 +2655,7 @@ macro_rules! cast {
 
         #[cfg(feature = "try-from")]
         impl TryFrom<i16> for $medium16 {
-            type Error = <i8 as TryFrom<i16>>::Error;
+            type Error = TryFromIntError;
 
             fn try_from(x: i16) -> Result<Self, Self::Error> {
                 Self::cast(x)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,9 @@ extern crate num_traits;
 use core::cmp::Ordering;
 use core::marker::PhantomData;
 use core::{fmt, ops};
+use core::num::TryFromIntError;
 
-#[cfg(feature = "try_from")]
+#[cfg(feature = "try-from")]
 use core::convert::{TryFrom, Infallible};
 
 use cast::{From as CastFrom, Error, f32, f64, i16, i32, i64, i8, isize, u16, u32, u64, u8, usize};
@@ -192,7 +193,7 @@ macro_rules! q {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl<FRAC> TryFrom<f32> for Q<$bits, FRAC>
         where
             FRAC: Cmp<U0, Output = Greater> +
@@ -221,7 +222,7 @@ macro_rules! q {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl<FRAC> TryFrom<f64> for Q<$bits, FRAC>
         where
             FRAC: Cmp<U0, Output = Greater> +
@@ -878,7 +879,7 @@ macro_rules! cast {
      $(+ $large32:ident,)*
      $(| $medium32:ident $medium16:ident,)+
      $(- $small32:ident $small16:ident $small8:ident,)+) => {
-         #[cfg(feature = "try_from")]
+         #[cfg(feature = "try-from")]
          impl TryFrom<$largest32> for isize {
              type Error = Infallible;
 
@@ -895,7 +896,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<isize> for $largest32 {
             type Error = TryFromIntError;
 
@@ -926,7 +927,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $largest32 {
             type Error = TryFromIntError;
 
@@ -957,7 +958,7 @@ macro_rules! cast {
             }
 
             }
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $largest32 {
             type Error = TryFromIntError;
 
@@ -991,7 +992,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$largest32> for i8 {
             type Error = TryFromIntError;
 
@@ -1022,7 +1023,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$largest32> for usize {
             type Error = TryFromIntError;
 
@@ -1039,7 +1040,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<usize> for $largest32 {
             type Error = TryFromIntError;
 
@@ -1056,7 +1057,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$largest32> for u64 {
             type Error = TryFromIntError;
 
@@ -1073,7 +1074,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $largest32 {
             type Error = TryFromIntError;
 
@@ -1090,7 +1091,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$largest32> for u32 {
             type Error = TryFromIntError;
 
@@ -1107,7 +1108,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $largest32 {
             type Error = TryFromIntError;
 
@@ -1124,7 +1125,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$largest32> for u16 {
             type Error = TryFromIntError;
 
@@ -1144,7 +1145,7 @@ macro_rules! cast {
         // Special case handled below
         // impl cast::From<u16> for $largest32 {}
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$largest32> for u8 {
             type Error = TryFromIntError;
 
@@ -1193,7 +1194,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $large32 {
                 type Error = TryFromIntError;
 
@@ -1231,7 +1232,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $medium32 {
                 type Error = TryFromIntError;
 
@@ -1265,7 +1266,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $medium16 {
                 type Error = TryFromIntError;
 
@@ -1300,7 +1301,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $small32 {
                 type Error = TryFromIntError;
 
@@ -1334,7 +1335,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $small16 {
                 type Error = TryFromIntError;
 
@@ -1365,7 +1366,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$largest32> for $small8 {
                 type Error = TryFromIntError;
 
@@ -1393,7 +1394,7 @@ macro_rules! cast {
     (| $large32:ident $large16:ident,
      $(| $medium32:ident $medium16:ident,)*
      $(- $small32:ident $small16:ident $small8:ident,)+) => {
-         #[cfg(feature = "try_from")]
+         #[cfg(feature = "try-from")]
          impl TryFrom<$large32> for isize {
              type Error = Infallible;
 
@@ -1410,7 +1411,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<isize> for $large32 {
             type Error = TryFromIntError;
 
@@ -1441,7 +1442,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $large32 {
             type Error = TryFromIntError;
 
@@ -1472,7 +1473,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $large32 {
             type Error = TryFromIntError;
 
@@ -1503,7 +1504,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i16> for $large32 {
             type Error = TryFromIntError;
 
@@ -1537,7 +1538,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$large32> for usize {
             type Error = TryFromIntError;
 
@@ -1554,7 +1555,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<usize> for $large32 {
             type Error = TryFromIntError;
 
@@ -1571,7 +1572,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$large32> for u64 {
             type Error = TryFromIntError;
 
@@ -1588,7 +1589,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $large32 {
             type Error = TryFromIntError;
 
@@ -1605,7 +1606,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$large32> for u32 {
             type Error = TryFromIntError;
 
@@ -1622,7 +1623,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $large32 {
             type Error = TryFromIntError;
 
@@ -1639,7 +1640,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$large32> for u16 {
             type Error = TryFromIntError;
 
@@ -1656,7 +1657,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u16> for $large32 {
             type Error = TryFromIntError;
 
@@ -1673,7 +1674,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$large32> for u8 {
             type Error = TryFromIntError;
 
@@ -1693,7 +1694,7 @@ macro_rules! cast {
         // Special case handled below
         // impl cast::From<u8> for $large32 {}
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$large16> for isize {
             type Error = <isize as TryFrom<i16>>::Error;
 
@@ -1710,7 +1711,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<isize> for $large16 {
             type Error = <i8 as TryFrom<isize>>::Error;
 
@@ -1741,7 +1742,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $large16 {
             type Error = TryFromIntError;
 
@@ -1772,7 +1773,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $large16 {
             type Error = TryFromIntError;
 
@@ -1803,7 +1804,7 @@ macro_rules! cast {
 
             }
         }
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i16> for $large16 {
             type Error = TryFromIntError;
 
@@ -1837,7 +1838,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$large16> for usize {
             type Error = TryFromIntError;
 
@@ -1854,7 +1855,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<usize> for $large16 {
             type Error = TryFromIntError;
 
@@ -1871,7 +1872,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$large16> for u64 {
             type Error = TryFromIntError;
 
@@ -1888,12 +1889,12 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $large16 {
             type Error = TryFromIntError;
 
             fn try_from(x: u64) -> Result<Self, Self::Error> {
-                iSelf::cast(x)
+                Self::cast(x)
             }
         }
 
@@ -1905,7 +1906,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$large16> for u32 {
             type Error = TryFromIntError;
 
@@ -1922,7 +1923,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $large16 {
             type Error = TryFromIntError;
 
@@ -1939,7 +1940,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$large16> for u16 {
             type Error = TryFromIntError;
 
@@ -1956,7 +1957,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u16> for $large16 {
             type Error = TryFromIntError;
 
@@ -1973,7 +1974,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$large16> for u8 {
             type Error = TryFromIntError;
 
@@ -2044,7 +2045,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$large32> for $medium32 {
                 type Error = TryFromIntError;
 
@@ -2078,7 +2079,7 @@ macro_rules! cast {
                 }
 
                 }
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$large32> for $medium16 {
                 type Error = TryFromIntError;
 
@@ -2109,7 +2110,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$large16> for $medium32 {
                 type Error = TryFromIntError;
 
@@ -2142,7 +2143,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$large16> for $medium16 {
                 type Error = TryFromIntError;
 
@@ -2179,7 +2180,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$large32> for $small32 {
                 type Error = TryFromIntError;
 
@@ -2213,7 +2214,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$large32> for $small16 {
                 type Error = TryFromIntError;
 
@@ -2244,7 +2245,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$large32> for $small8 {
                 type Error = TryFromIntError;
 
@@ -2275,7 +2276,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$large16> for $small32 {
                 type Error = TryFromIntError;
 
@@ -2308,7 +2309,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$large16> for $small16 {
                 type Error = TryFromIntError;
 
@@ -2341,7 +2342,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$large16> for $small8 {
                 type Error = TryFromIntError;
 
@@ -2383,7 +2384,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<isize> for $medium32 {
             type Error = TryFromIntError;
 
@@ -2414,7 +2415,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $medium32 {
             type Error = TryFromIntError;
 
@@ -2445,7 +2446,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $medium32 {
             type Error = TryFromIntError;
 
@@ -2476,7 +2477,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i16> for $medium32 {
             type Error = TryFromIntError;
 
@@ -2507,7 +2508,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i8> for $medium32 {
             type Error = TryFromIntError;
 
@@ -2525,7 +2526,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium32> for usize {
             type Error = TryFromIntError;
 
@@ -2542,7 +2543,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<usize> for $medium32 {
             type Error = TryFromIntError;
 
@@ -2559,7 +2560,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium32> for u64 {
             type Error = TryFromIntError;
 
@@ -2576,7 +2577,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $medium32 {
             type Error = TryFromIntError;
 
@@ -2593,7 +2594,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium32> for u32 {
             type Error = TryFromIntError;
 
@@ -2610,7 +2611,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $medium32 {
             type Error = TryFromIntError;
 
@@ -2627,7 +2628,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium32> for u16 {
             type Error = TryFromIntError;
 
@@ -2644,7 +2645,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u16> for $medium32 {
             type Error = TryFromIntError;
 
@@ -2661,7 +2662,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium32> for u8 {
             type Error = TryFromIntError;
 
@@ -2678,7 +2679,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u8> for $medium32 {
             type Error = TryFromIntError;
 
@@ -2709,7 +2710,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<isize> for $medium16 {
             type Error = TryFromIntError;
 
@@ -2740,7 +2741,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $medium16 {
             type Error = TryFromIntError;
 
@@ -2771,7 +2772,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $medium16 {
             type Error = TryFromIntError;
 
@@ -2802,7 +2803,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i16> for $medium16 {
             type Error = <i8 as TryFrom<i16>>::Error;
 
@@ -2833,7 +2834,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i8> for $medium16 {
             type Error = TryFromIntError;
 
@@ -2851,7 +2852,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium16> for usize {
             type Error = TryFromIntError;
 
@@ -2868,7 +2869,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<usize> for $medium16 {
             type Error = TryFromIntError;
 
@@ -2885,7 +2886,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium16> for u64 {
             type Error = TryFromIntError;
 
@@ -2902,7 +2903,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $medium16 {
             type Error = TryFromIntError;
 
@@ -2919,7 +2920,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium16> for u32 {
             type Error = TryFromIntError;
 
@@ -2936,7 +2937,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $medium16 {
             type Error = TryFromIntError;
 
@@ -2953,7 +2954,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium16> for u16 {
             type Error = TryFromIntError;
 
@@ -2970,7 +2971,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u16> for $medium16 {
             type Error = TryFromIntError;
 
@@ -2987,7 +2988,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium16> for u8 {
             type Error = TryFromIntError;
 
@@ -3004,7 +3005,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u8> for $medium16 {
             type Error = TryFromIntError;
 
@@ -3035,7 +3036,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<isize> for $medium8 {
             type Error = TryFromIntError;
 
@@ -3066,7 +3067,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i64> for $medium8 {
             type Error = TryFromIntError;
 
@@ -3097,7 +3098,7 @@ macro_rules! cast {
             }
 
             }
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i32> for $medium8 {
             type Error = TryFromIntError;
 
@@ -3128,7 +3129,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i16> for $medium8 {
             type Error = TryFromIntError;
 
@@ -3159,7 +3160,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<i8> for $medium8 {
             type Error = TryFromIntError;
 
@@ -3177,7 +3178,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium8> for usize {
             type Error = TryFromIntError;
 
@@ -3194,7 +3195,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<usize> for $medium8 {
             type Error = TryFromIntError;
 
@@ -3211,7 +3212,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium8> for u64 {
             type Error = TryFromIntError;
 
@@ -3228,7 +3229,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u64> for $medium8 {
             type Error = TryFromIntError;
 
@@ -3245,7 +3246,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium8> for u32 {
             type Error = TryFromIntError;
 
@@ -3262,7 +3263,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u32> for $medium8 {
             type Error = TryFromIntError;
 
@@ -3279,7 +3280,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium8> for u16 {
             type Error = TryFromIntError;
 
@@ -3296,7 +3297,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u16> for $medium8 {
             type Error = TryFromIntError;
 
@@ -3313,7 +3314,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<$medium8> for u8 {
             type Error = TryFromIntError;
 
@@ -3330,7 +3331,7 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try_from")]
+        #[cfg(feature = "try-from")]
         impl TryFrom<u8> for $medium8 {
             type Error = TryFromIntError;
 
@@ -3450,7 +3451,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$medium32> for $small32 {
                 type Error = TryFromIntError;
 
@@ -3483,7 +3484,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$medium32> for $small16 {
                 type Error = TryFromIntError;
 
@@ -3514,7 +3515,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$medium32> for $small8 {
                 type Error = TryFromIntError;
 
@@ -3545,7 +3546,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$medium16> for $small32 {
                 type Error = TryFromIntError;
 
@@ -3577,7 +3578,7 @@ macro_rules! cast {
                                           $medium16::fbits()))
                 }
             }
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$medium16> for $small16 {
                 type Error = TryFromIntError;
 
@@ -3610,7 +3611,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$medium16> for $small8 {
                 type Error = TryFromIntError;
 
@@ -3641,7 +3642,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$medium8> for $small32 {
                 type Error = TryFromIntError;
 
@@ -3672,7 +3673,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$medium8> for $small16 {
                 type Error = TryFromIntError;
 
@@ -3705,7 +3706,7 @@ macro_rules! cast {
                 }
             }
 
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$medium8> for $small8 {
                 type Error = TryFromIntError;
 
@@ -3772,7 +3773,7 @@ cast! {
 macro_rules! to_ixx {
     ($ixx:ident; $($q:ident),+) => {
         $(
-            #[cfg(feature = "try_from")]
+            #[cfg(feature = "try-from")]
             impl TryFrom<$q> for $ixx {
                 type Error = TryFromIntError;
 
@@ -3843,7 +3844,7 @@ to_ixx!(i16;
         I18F14,
         I17F15);
 
-#[cfg(feature = "try_from")]
+#[cfg(feature = "try-from")]
 impl TryFrom<u16> for I16F16 {
     type Error = TryFromIntError;
 
@@ -3893,7 +3894,7 @@ impl cast::From<I8F24> for i8 {
 
 to_ixx!(i8; I15F17, I14F18, I13F19, I12F20, I11F21, I10F22, I9F23);
 
-#[cfg(feature = "try_from")]
+#[cfg(feature = "try-from")]
 impl TryFrom<u8> for I8F24 {
     type Error = Error;
 
@@ -3928,7 +3929,7 @@ impl cast::From<I8F8> for i8 {
 
 to_ixx!(i8; I15F1, I14F2, I13F3, I12F4, I11F5, I10F6, I9F7);
 
-#[cfg(feature = "try_from")]
+#[cfg(feature = "try-from")]
 impl TryFrom<u8> for I8F8 {
     type Error = Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3648,7 +3648,7 @@ impl TryFrom<u16> for I16F16 {
     type Error = TryFromIntError;
 
     fn try_from(x: u16) -> Result<Self, Self::Error> {
-        i32::try_from(u32::from(x) << I16F16::fbits()).map(I16F16::from_bits)
+        Self::cast(x)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -879,29 +879,11 @@ macro_rules! cast {
      $(+ $large32:ident,)*
      $(| $medium32:ident $medium16:ident,)+
      $(- $small32:ident $small16:ident $small8:ident,)+) => {
-         #[cfg(feature = "try-from")]
-         impl TryFrom<$largest32> for isize {
-             type Error = Infallible;
-
-             fn try_from(x: $largest32) -> Result<Self, Self::Error> {
-                 Self::cast(x)
-             }
-         }
-
         impl cast::From<$largest32> for isize {
             type Output = Self;
 
             fn cast(x: $largest32) -> Self::Output {
                 isize(i32(x))
-            }
-        }
-
-        #[cfg(feature = "try-from")]
-        impl TryFrom<isize> for $largest32 {
-            type Error = TryFromIntError;
-
-            fn try_from(x: isize) -> Result<Self, Self::Error> {
-                Self::cast(x)
             }
         }
 
@@ -1023,29 +1005,11 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try-from")]
-        impl TryFrom<$largest32> for usize {
-            type Error = TryFromIntError;
-
-            fn try_from(x: $largest32) -> Result<Self, Self::Error> {
-                Self::cast(x)
-            }
-        }
-
         impl cast::From<$largest32> for usize {
             type Output = Result<Self, Error>;
 
             fn cast(x: $largest32) -> Self::Output {
                 usize(i32(x))
-            }
-        }
-
-        #[cfg(feature = "try-from")]
-        impl TryFrom<usize> for $largest32 {
-            type Error = TryFromIntError;
-
-            fn try_from(x: usize) -> Result<Self, Self::Error> {
-                Self::cast(x)
             }
         }
 
@@ -1394,29 +1358,11 @@ macro_rules! cast {
     (| $large32:ident $large16:ident,
      $(| $medium32:ident $medium16:ident,)*
      $(- $small32:ident $small16:ident $small8:ident,)+) => {
-         #[cfg(feature = "try-from")]
-         impl TryFrom<$large32> for isize {
-             type Error = Infallible;
-
-             fn try_from(x: $large32) -> Result<Self, Self::Error> {
-                 Self::cast(x)
-             }
-         }
-
         impl cast::From<$large32> for isize {
             type Output = Self;
 
             fn cast(x: $large32) -> Self::Output {
                 isize(i16(x))
-            }
-        }
-
-        #[cfg(feature = "try-from")]
-        impl TryFrom<isize> for $large32 {
-            type Error = TryFromIntError;
-
-            fn try_from(x: isize) -> Result<Self, Self::Error> {
-                Self::cast(x)
             }
         }
 
@@ -1538,29 +1484,11 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try-from")]
-        impl TryFrom<$large32> for usize {
-            type Error = TryFromIntError;
-
-            fn try_from(x: $large32) -> Result<Self, Self::Error> {
-                Self::cast(x)
-            }
-        }
-
         impl cast::From<$large32> for usize {
             type Output = Result<Self, Error>;
 
             fn cast(x: $large32) -> Self::Output {
                 usize(i16(x))
-            }
-        }
-
-        #[cfg(feature = "try-from")]
-        impl TryFrom<usize> for $large32 {
-            type Error = TryFromIntError;
-
-            fn try_from(x: usize) -> Result<Self, Self::Error> {
-                Self::cast(x)
             }
         }
 
@@ -1694,29 +1622,11 @@ macro_rules! cast {
         // Special case handled below
         // impl cast::From<u8> for $large32 {}
 
-        #[cfg(feature = "try-from")]
-        impl TryFrom<$large16> for isize {
-            type Error = <isize as TryFrom<i16>>::Error;
-
-            fn try_from(x: $large16) -> Result<Self, Self::Error> {
-                Self::cast(x)
-            }
-        }
-
         impl cast::From<$large16> for isize {
             type Output = Self;
 
             fn cast(x: $large16) -> Self::Output {
                 isize(i16(x))
-            }
-        }
-
-        #[cfg(feature = "try-from")]
-        impl TryFrom<isize> for $large16 {
-            type Error = <i8 as TryFrom<isize>>::Error;
-
-            fn try_from(x: isize) -> Result<Self, Self::Error> {
-                Self::cast(x)
             }
         }
 
@@ -1838,29 +1748,11 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try-from")]
-        impl TryFrom<$large16> for usize {
-            type Error = TryFromIntError;
-
-            fn try_from(x: $large16) -> Result<Self, Self::Error> {
-                Self::cast(x)
-            }
-        }
-
         impl cast::From<$large16> for usize {
             type Output = Result<Self, Error>;
 
             fn cast(x: $large16) -> Self::Output {
                 usize(i16(x))
-            }
-        }
-
-        #[cfg(feature = "try-from")]
-        impl TryFrom<usize> for $large16 {
-            type Error = TryFromIntError;
-
-            fn try_from(x: usize) -> Result<Self, Self::Error> {
-                Self::cast(x)
             }
         }
 
@@ -2370,26 +2262,11 @@ macro_rules! cast {
      $(- $small32:ident $small16:ident $small8:ident,)*) => {
         // Cast from/to primitives
 
-        impl From<$medium32> for isize {
-            fn from(x: $medium32) -> Self {
-                Self::cast(x)
-            }
-        }
-
         impl cast::From<$medium32> for isize {
             type Output = Self;
 
             fn cast(x: $medium32) -> Self::Output {
                 isize(i8(x))
-            }
-        }
-
-        #[cfg(feature = "try-from")]
-        impl TryFrom<isize> for $medium32 {
-            type Error = TryFromIntError;
-
-            fn try_from(x: isize) -> Result<Self, Self::Error> {
-                Self::cast(x)
             }
         }
 
@@ -2526,29 +2403,11 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try-from")]
-        impl TryFrom<$medium32> for usize {
-            type Error = TryFromIntError;
-
-            fn try_from(x: $medium32) -> Result<Self, Self::Error> {
-                Self::cast(x)
-            }
-        }
-
         impl cast::From<$medium32> for usize {
             type Output = Result<Self, Error>;
 
             fn cast(x: $medium32) -> Self::Output {
                 usize(i8(x))
-            }
-        }
-
-        #[cfg(feature = "try-from")]
-        impl TryFrom<usize> for $medium32 {
-            type Error = TryFromIntError;
-
-            fn try_from(x: usize) -> Result<Self, Self::Error> {
-                Self::cast(x)
             }
         }
 
@@ -2710,15 +2569,6 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try-from")]
-        impl TryFrom<isize> for $medium16 {
-            type Error = TryFromIntError;
-
-            fn try_from(x: isize) -> Result<Self, Self::Error> {
-                Self::cast(x)
-        }
-        }
-
         impl cast::From<isize> for $medium16 {
             type Output = Result<$medium16, Error>;
 
@@ -2852,29 +2702,11 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try-from")]
-        impl TryFrom<$medium16> for usize {
-            type Error = TryFromIntError;
-
-            fn try_from(x: $medium16) -> Result<Self, Self::Error> {
-                Self::cast(x)
-            }
-        }
-
         impl cast::From<$medium16> for usize {
             type Output = Result<Self, Error>;
 
             fn cast(x: $medium16) -> Self::Output {
                 usize(i8(x))
-            }
-        }
-
-        #[cfg(feature = "try-from")]
-        impl TryFrom<usize> for $medium16 {
-            type Error = TryFromIntError;
-
-            fn try_from(x: usize) -> Result<Self, Self::Error> {
-                Self::cast(x)
             }
         }
 
@@ -3022,26 +2854,11 @@ macro_rules! cast {
             }
         }
 
-        impl From<$medium8> for isize {
-            fn from(x: $medium8) -> Self {
-                Self::cast(x)
-            }
-        }
-
         impl cast::From<$medium8> for isize {
             type Output = Self;
 
             fn cast(x: $medium8) -> Self::Output {
                 isize(i8(x))
-            }
-        }
-
-        #[cfg(feature = "try-from")]
-        impl TryFrom<isize> for $medium8 {
-            type Error = TryFromIntError;
-
-            fn try_from(x: isize) -> Result<Self, Self::Error> {
-                Self::cast(x)
             }
         }
 
@@ -3178,29 +2995,11 @@ macro_rules! cast {
             }
         }
 
-        #[cfg(feature = "try-from")]
-        impl TryFrom<$medium8> for usize {
-            type Error = TryFromIntError;
-
-            fn try_from(x: $medium8) -> Result<Self, Self::Error> {
-                Self::cast(x)
-            }
-        }
-
         impl cast::From<$medium8> for usize {
             type Output = Result<Self, Error>;
 
             fn cast(x: $medium8) -> Self::Output {
                 usize(i8(x))
-            }
-        }
-
-        #[cfg(feature = "try-from")]
-        impl TryFrom<usize> for $medium8 {
-            type Error = TryFromIntError;
-
-            fn try_from(x: usize) -> Result<Self, Self::Error> {
-                Self::cast(x)
             }
         }
 

--- a/tests/cast.rs
+++ b/tests/cast.rs
@@ -1,26 +1,32 @@
+#![cfg_attr(feature = "try-from", feature(try_from))]
+
 extern crate cast;
 extern crate fpa;
 
+use cast::*;
+use fpa::*;
+
+#[allow(unused_imports)]
+#[cfg(feature = "try-from")]
+use std::convert::TryFrom;
+
 #[cfg(test)]
 mod cross {
-    use cast::*;
-    use fpa::*;
+    use super::*;
 
     include!(concat!(env!("OUT_DIR"), "/cross.rs"));
 }
 
 #[cfg(test)]
 mod to {
-    use cast::*;
-    use fpa::*;
+    use super::*;
 
     include!(concat!(env!("OUT_DIR"), "/to-ixx.rs"));
 }
 
 #[cfg(test)]
 mod from {
-    use cast::*;
-    use fpa::*;
+    use super::*;
 
     include!(concat!(env!("OUT_DIR"), "/from-ixx.rs"));
 }


### PR DESCRIPTION
Turns out generating shim code via `build.rs` and relying on being correct without compiling/running any of it during testing is a bad idea. Code that does not get compiled won't fail tests either. Embarrassing.

Fixes:
- I used `#[cfg(feature = “try_from”)]` instead `#[cfg(feature = “try-from”)]` causing my code to not even get generated. (#fdda4b1)
- Had a wrong error type in one function that did not get caught. (#07319d7)
- Had a wrong implementation in one function that did not get caught. (#e3d0328)

Changes:
- Switched errors from `core::num::TryFromIntError` to `cast::Error`. (#35a3fbd)
- Removed impls of `TryFrom` for `usize`/`isize` to mirror ‘stdlib’. (#67a17b1)
- Refactored unit tests. Let’s actually run them this time, shall we? (#b134161)

As part of the unit test refactoring we are now also:
- Testing `From` and `TryFrom` for every variant of `cast::From`, where applicable.
- Splitting asserts into smaller test functions making it easier to see what's wrong.

We now have **418 tests** for `num-traits` and **477 tests** for `cast::From`/`From`/`TryFrom`.