### PR TITLE
Mark implementations of num-traits actually as `pub`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,8 @@ use typenum::{Cmp, Greater, Less, U0, U1, U2, U3, U4, U5, U6, U7, U8, U9, U10,
 
 mod num_traits_impl;
 
+pub use num_traits_impl::*;
+
 /// Fixed point number
 ///
 /// - `BITS` is the integer primitive used to stored the number

--- a/src/num_traits_impl.rs
+++ b/src/num_traits_impl.rs
@@ -10,6 +10,9 @@ use cast;
 
 use Q;
 
+/// An error which can be returned when parsing a fixed-point number.
+///
+/// This error is used as the error type for the `from_str_radix()`` functions.
 #[derive(PartialEq, Debug)]
 pub struct ParseFixedError;
 


### PR DESCRIPTION
… as they should have been from the let go.

After all, what's the point of implementing all this stuff if you're then not making it accessible? 🤦🏻‍♂️